### PR TITLE
Add top level hash function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ NOTE: this will bring a breaking change as we will need
 
 ---
 
+## v1.3.0
+
+- Add the `fingerprint.hash(headers, [options])` top-level API
+
 ## v1.2.0
 
 - Add `rewriteHeaders` option

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Although this is certainly true, fingerprinting **CAN BE USED TO INCREASE A SYST
 
 ## Usage
 
+Add this library as Fastify plugin:
+
 ```js
 const fingerprint = require("fastify-fingerprint");
 
@@ -32,6 +34,21 @@ fastify.route({
   url: "/fingerprint",
   handler: (request, reply) => {
     reply.send(`ClientID: ${request.fingerprint}`);
+  },
+});
+```
+
+Use it with plain API:
+
+```js
+const fingerprint = require("fastify-fingerprint");
+
+fastify.route({
+  method: "GET",
+  url: "/fingerprint",
+  handler: (request, reply) => {
+    const clientId = fingerprint.hash(request.headers, { ...options });
+    reply.send(`ClientID: ${clientId}`);
   },
 });
 ```

--- a/index.js
+++ b/index.js
@@ -1,32 +1,11 @@
 const fp = require("fastify-plugin");
-const defaultHashFn = require("./src/hash");
-const filterHeadersFn = require("./src/filter-headers");
-const rewriteHeadersFn = require("./src/rewrite-headers");
+const fingerprintFn = require("./src/fingerprint");
 
+// Export the plugin
 module.exports = fp(
-  (
-    fastify,
-    {
-      acceptHeaders = undefined,
-      extendHeaders = undefined,
-      rewriteHeaders = undefined,
-      acceptCookies = undefined,
-      requestKey = "fingerprint",
-      hashFn = defaultHashFn,
-    } = {},
-    next
-  ) => {
+  (fastify, { requestKey = "fingerprint", ...options } = {}, next) => {
     const preValidation = async (request) => {
-      const values = rewriteHeadersFn(
-        filterHeadersFn(request.headers, {
-          acceptHeaders,
-          extendHeaders,
-          acceptCookies,
-        }),
-        rewriteHeaders
-      );
-
-      request[requestKey] = hashFn(values);
+      request[requestKey] = fingerprintFn(request.headers, options);
     };
 
     fastify.decorateRequest(requestKey, null);
@@ -35,3 +14,6 @@ module.exports = fp(
     next();
   }
 );
+
+// Export the API
+module.exports.hash = fingerprintFn;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-fingerprint",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Generate a header-based fingerprint of the request",
   "main": "index.js",
   "scripts": {

--- a/src/fingerprint.js
+++ b/src/fingerprint.js
@@ -1,0 +1,25 @@
+const defaultHashFn = require("./hash");
+const filterHeadersFn = require("./filter-headers");
+const rewriteHeadersFn = require("./rewrite-headers");
+
+module.exports = (
+  headers = {},
+  {
+    acceptHeaders = undefined,
+    extendHeaders = undefined,
+    rewriteHeaders = undefined,
+    acceptCookies = undefined,
+    hashFn = defaultHashFn,
+  } = {}
+) => {
+  const values = rewriteHeadersFn(
+    filterHeadersFn(headers, {
+      acceptHeaders,
+      extendHeaders,
+      acceptCookies,
+    }),
+    rewriteHeaders
+  );
+
+  return hashFn(values);
+};


### PR DESCRIPTION
- Add the `fingerprint.hash(headers, [options])` top-level API